### PR TITLE
Change code copy logic

### DIFF
--- a/src/components/Code.svelte
+++ b/src/components/Code.svelte
@@ -35,7 +35,6 @@
 <style>
   .wrapper {
     position: relative;
-    cursor: pointer;
   }
 
   .wrapper:hover .copy {
@@ -43,6 +42,7 @@
   }
 
   .copy {
+    z-index: 10;
     opacity: 0;
     background: #fff;
     color: #000;
@@ -52,7 +52,6 @@
     position: absolute;
     top: 20px;
     right: 20px;
-    pointer-events: none;
   }
 
   .heading {
@@ -80,6 +79,6 @@
 
 <div class="wrapper">
   <h2 class="heading">code</h2>
-  <pre bind:this={pre} on:click={copy} />
-  <div class="copy">{copyText}</div>
+  <pre bind:this={pre} />
+  <button class="copy" on:click={copy}>{copyText}</button>
 </div>


### PR DESCRIPTION
When reading the docs, I wanted to copy only parts of the example instead of the complete code.
With the current logic to just copy it whenever you click inside the code block, this is not possible. What happens is:
* You select some piece of code
* The complete code (not just the selected one) gets copied to your clipboard
* The selection gets cleared, so you cannot just overwrite the clipboard by pressing `Ctrl + C`
![g4UfPfMvzA](https://user-images.githubusercontent.com/5033001/116793943-0e99ac80-aaca-11eb-9a94-4c77ef3aec18.gif)

What I ended up doing, was copying everything, then pasting it in a Notepad and copying the parts from there. Which is not a very nice experience 😄 

With the changes, the `Copy` text is now a button that can be clicked to copy everything. This allows you to copy a selection the "old-fashioned" way if you want to.
![bKwTywsjl3](https://user-images.githubusercontent.com/5033001/116794055-a1d2e200-aaca-11eb-898f-756d54fbf3f3.gif)

